### PR TITLE
Docker test　二

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,21 +223,21 @@ jobs:
   #             exit 1
   #         fi
 
-  Ubuntu_Build:
+  Docker_Build:
     # needs: Sanity_Checks
     runs-on: ubuntu-latest
     env:
-      os: ubuntu
-      package_manager: apt
+      package_manager: ${{ matrix.os == 'alpine' && 'apk' || 'apt' }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - compiler: gcc
+          - os: ubuntu
+            compiler: gcc
             build_type: Release
-          - compiler: clang
+          - os: ubuntu
+            compiler: clang
             build_type: RelWithDebInfo
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -266,23 +266,23 @@ jobs:
             type=sha
           labels: |
             org.opencontainers.image.authors=LandSandBoat Dev Teams
-            org.opencontainers.image.title=LandSandBoat Server (${{ env.os }})
+            org.opencontainers.image.title=LandSandBoat Server (${{ matrix.os }})
             org.opencontainers.image.documentation=https://github.com/LandSandBoat/server/wiki
           flavor: ${{ format('suffix=-{0}', matrix.compiler) }}
 
       - name: Restore packages cache
         uses: actions/cache/restore@v4
         env:
-          hash: ${{ hashFiles(format('./docker/{0}.Dockerfile', env.os), './tools/requirements.txt') }}
+          hash: ${{ hashFiles(format('./docker/{0}.Dockerfile', matrix.os), './tools/requirements.txt') }}
         with:
           path: |
             ${{ format('var-cache-{0}', env.package_manager) }}
-            ${{ format('cache-pip-{0}', env.os) }}
-            ${{ env.os == 'ubuntu' && 'var-lib-apt' || '' }}
-          key: packagecache-${{ env.os }}-${{ env.hash }}-${{ github.base_ref }}
+            ${{ format('cache-pip-{0}', matrix.os) }}
+            ${{ matrix.os == 'ubuntu' && 'var-lib-apt' || '' }}
+          key: packagecache-${{ matrix.os }}-${{ env.hash }}-${{ github.base_ref }}
           restore-keys: |
-            packagecache-${{ env.os }}-${{ env.hash }}-
-            packagecache-${{ env.os }}-
+            packagecache-${{ matrix.os }}-${{ env.hash }}-
+            packagecache-${{ matrix.os }}-
 
       - name: Restore build cache
         uses: actions/cache/restore@v4
@@ -290,17 +290,50 @@ jobs:
           hash: ${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
         with:
           path: |
-            ${{ format('build-{0}-{1}', env.os, matrix.compiler ) }}
-            ${{ format('ccache-{0}-{1}', env.os, matrix.compiler ) }}
-          key: buildcache-${{ env.os }}-${{ matrix.compiler }}-${{ env.hash }}-${{ github.base_ref }}
+            ${{ format('build-{0}-{1}', matrix.os, matrix.compiler ) }}
+            ${{ format('ccache-{0}-{1}', matrix.os, matrix.compiler ) }}
+          key: buildcache-${{ matrix.os }}-${{ env.hash }}-${{ matrix.compiler }}-${{ github.base_ref }}
           restore-keys: |
-            buildcache-${{ env.os }}-${{ matrix.compiler }}-${{ env.hash }}-
+            buildcache-${{ matrix.os }}-${{ env.hash }}-${{ matrix.compiler }}-
 
       # https://github.com/reproducible-containers/buildkit-cache-dance/issues/33
       - name: Inject cache
         uses: reproducible-containers/buildkit-cache-dance@v3.2.0
         with:
-          dockerfile: ${{ format('./docker/{0}.Dockerfile', env.os) }}
+          cache-map: |
+            {
+              "${{ format('var-cache-{0}', env.package_manager) }}":
+                {
+                  "target": "${{ format('/var/cache/{0}', env.package_manager) }}",
+                  "id": "${{ format('var-cache-{0}', env.package_manager) }}"
+                },
+              "${{ format('var-lib-{0}', env.package_manager) }}":
+                {
+                  "target": "${{ format('/var/lib/{0}', env.package_manager) }}",
+                  "id": "${{ format('var-lib-{0}', env.package_manager) }}"
+                },
+              "${{ format('cache-pip-{0}', matrix.os) }}":
+                {
+                  "target": "/xiadmin/.cache/pip",
+                  "id": "${{ format('cache-pip-{0}', matrix.os) }}",
+                  "uid": 1000,
+                  "gid": 1000
+                },
+              "${{ format('build-{0}-{1}', matrix.os, matrix.compiler ) }}":
+                {
+                  "target": "/xiadmin/build",
+                  "id": "${{ format('build-{0}-{1}', matrix.os, matrix.compiler ) }}",
+                  "uid": 1000,
+                  "gid": 1000
+                },
+              "${{ format('ccache-{0}-{1}', matrix.os, matrix.compiler ) }}":
+                {
+                  "target": "/xiadmin/.ccache",
+                  "id": "${{ format('ccache-{0}-{1}', matrix.os, matrix.compiler ) }}",
+                  "uid": 1000,
+                  "gid": 1000
+                }
+            }
           skip-extraction: true
 
       - name: Build and push
@@ -309,13 +342,13 @@ jobs:
           BUILDX_NO_DEFAULT_ATTESTATIONS: 1 # https://github.com/orgs/community/discussions/45969
         with:
           context: .
-          file: ${{ format('./docker/{0}.Dockerfile', env.os) }}
+          file: ${{ format('./docker/{0}.Dockerfile', matrix.os) }}
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           platforms: linux/amd64
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/buildcache:server-${{ github.base_ref }}-${{ env.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/buildcache:server-${{ github.base_ref }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}
           build-args: |
             COMPILER=${{ matrix.compiler }}
             CMAKE_BUILD_TYPE=${{ matrix.build_type }}

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -12,20 +12,20 @@ concurrency:
 
 jobs:
   Build_Packages:
+    runs-on: ubuntu-latest
+    env:
+      package_manager: ${{ matrix.os == 'alpine' && 'apk' || 'apt' }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu
-            package_manager: apt
             compiler: gcc
             build_type: Release
           - os: alpine
-            package_manager: apk
             compiler: gcc
             build_type: Release
 
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,9 +67,9 @@ jobs:
           hash: ${{ hashFiles(format('./docker/{0}.Dockerfile', matrix.os), './tools/requirements.txt') }}
         with:
           path: |
-            ${{ format('var-cache-{0}', matrix.package_manager) }}
+            ${{ format('var-cache-{0}', env.package_manager) }}
+            ${{ format('var-lib-{0}', env.package_manager) }}
             ${{ format('cache-pip-{0}', matrix.os) }}
-            ${{ matrix.os == 'ubuntu' && 'var-lib-apt' || '' }}
           key: packagecache-${{ matrix.os }}-${{ env.hash }}-${{ github.ref_name }}
           restore-keys: |
             packagecache-${{ matrix.os }}-${{ env.hash }}-
@@ -83,15 +83,48 @@ jobs:
           path: |
             ${{ format('build-{0}-{1}', matrix.os, matrix.compiler ) }}
             ${{ format('ccache-{0}-{1}', matrix.os, matrix.compiler ) }}
-          key: buildcache-${{ matrix.os }}-${{ matrix.compiler }}-${{ env.hash }}-${{ github.ref_name }}
+          key: buildcache-${{ matrix.os }}-${{ env.hash }}-${{ matrix.compiler }}-${{ github.ref_name }}
           restore-keys: |
-            buildcache-${{ matrix.os }}-${{ matrix.compiler }}-${{ env.hash }}-
+            buildcache-${{ matrix.os }}-${{ env.hash }}-${{ matrix.compiler }}-
 
       # https://github.com/reproducible-containers/buildkit-cache-dance/issues/33
       - name: Inject cache
         uses: reproducible-containers/buildkit-cache-dance@v3.2.0
         with:
-          dockerfile: ${{ format('./docker/{0}.Dockerfile', matrix.os) }}
+          cache-map: |
+            {
+              "${{ format('var-cache-{0}', env.package_manager) }}":
+                {
+                  "target": "${{ format('/var/cache/{0}', env.package_manager) }}",
+                  "id": "${{ format('var-cache-{0}', env.package_manager) }}"
+                },
+              "${{ format('var-lib-{0}', env.package_manager) }}":
+                {
+                  "target": "${{ format('/var/lib/{0}', env.package_manager) }}",
+                  "id": "${{ format('var-lib-{0}', env.package_manager) }}"
+                },
+              "${{ format('cache-pip-{0}', matrix.os) }}":
+                {
+                  "target": "/xiadmin/.cache/pip",
+                  "id": "${{ format('cache-pip-{0}', matrix.os) }}",
+                  "uid": 1000,
+                  "gid": 1000
+                },
+              "${{ format('build-{0}-{1}', matrix.os, matrix.compiler ) }}":
+                {
+                  "target": "/xiadmin/build",
+                  "id": "${{ format('build-{0}-{1}', matrix.os, matrix.compiler ) }}",
+                  "uid": 1000,
+                  "gid": 1000
+                },
+              "${{ format('ccache-{0}-{1}', matrix.os, matrix.compiler ) }}":
+                {
+                  "target": "/xiadmin/.ccache",
+                  "id": "${{ format('ccache-{0}-{1}', matrix.os, matrix.compiler ) }}",
+                  "uid": 1000,
+                  "gid": 1000
+                }
+            }
           skip-extraction: false
 
       - name: Build and push

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/var/cache/apk,id=var-cache-apk,sharing=locked \
     apk --update-cache add \
     binutils-dev \
     ccache \
-    clang18 \
+    # clang18 \
     cmake \
     g++ \
     linux-headers \
@@ -75,6 +75,7 @@ COPY --chown=$UNAME:$UGROUP --exclude=.git --exclude=losmeshes/** --exclude=navm
 #########
 FROM staging AS build
 
+# clang requires fortify-headers which breaks the build
 ARG COMPILER=gcc
 ARG CMAKE_BUILD_TYPE=Release
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Testing Github Docker actions on PR.

Ideally this should trigger a build using the Docker build cache from the registry created when `latest` is published (to avoid reinstalling dependencies), itself triggered whenever there is a new commit to base.

Then it _should_ use the GitHub Actions cache for cache mounts during the build (`--mount=type=cache`). This way, even though file changes (including git metadata, so basically always for the cmake step) will invalidate the Docker layer cache, leaving us in a state with no prior cmake build artifacts, these cache mounts should be used to persist the build folder (and apt/pip cache if needed) meaning that for most changes we only rebuild version.cpp and any source changes. This would result in a minimum build time of about 3-4 minutes if there are no source file changes (e.g. scripting/SQL changes only) instead of rebuilding all of the executables (and dependencies like MariaDB Connector C++) for every workflow run.

buildkit-cache-dance  is supposed to facilitate this cache mounting but doesn't seem to work as expected.

