### PR TITLE
Revert clang-tidy-22 changes

### DIFF
--- a/.github/workflows/runner_build.yml
+++ b/.github/workflows/runner_build.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install dependencies (macOS)
         if: ${{ runner.os == 'macOS' && env.SKIP_BUILD != 'true' }}
         run: |
-          brew update && brew install --quiet \
+          brew install --quiet \
             mariadb \
             zeromq \
             luajit \
@@ -108,7 +108,7 @@ jobs:
       - name: Setup LLVM Clang (macOS)
         if: ${{ runner.os == 'macOS' && startsWith(inputs.compiler, 'clang') && env.SKIP_BUILD != 'true' }}
         run: |
-          brew update && brew install --quiet \
+          brew install --quiet \
             llvm@${{ inputs.compiler_version }} \
             lld@${{ inputs.compiler_version }}
 
@@ -128,7 +128,7 @@ jobs:
       - name: Setup GCC (macOS)
         if: ${{ runner.os == 'macOS' && startsWith(inputs.compiler, 'gcc') && env.SKIP_BUILD != 'true' }}
         run: |
-          brew update && brew install --quiet gcc@${{ inputs.compiler_version }}
+          brew install --quiet gcc@${{ inputs.compiler_version }}
           GCC_PREFIX=$(brew --prefix gcc@${{ inputs.compiler_version }})
           echo "PATH=$GCC_PREFIX/bin:$PATH" >> $GITHUB_ENV
           echo "CC=$GCC_PREFIX/bin/gcc-${{ inputs.compiler_version }}" >> $GITHUB_ENV


### PR DESCRIPTION
This reverts commit 86368762078a77f0d20a66c094b31bd13132b048.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Clang-tidy testing.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
